### PR TITLE
Gemfile for bundle install when running serverspec_eol

### DIFF
--- a/lib/busser/runner_plugin/serverspec_eol.rb
+++ b/lib/busser/runner_plugin/serverspec_eol.rb
@@ -44,7 +44,7 @@ class Busser::RunnerPlugin::ServerspecEol < Busser::RunnerPlugin::Base
 
   def run_bundle_install
     # Referred from busser-shindo
-    gemfile_path = File.join(suite_path, 'serverspec', 'Gemfile')
+    gemfile_path = File.join(suite_path, 'serverspec_eol', 'Gemfile')
     if File.exists?(gemfile_path)
       # Bundle install local completes quickly if the gems are already found
       # locally it fails if it needs to talk to the internet. The || below is


### PR DESCRIPTION
According to the doc, the Gemfile in `[COOKBOOK]/test/integration/[SUITES]/serverspec_eol/Gemfile` should be read. But no bundle install is done before to serverspec_eol test suites.

This commit fixes that.
Before this commit, even though we have a specific Gemfile located at `[COOKBOOK]/test/integration/[SUITES]/serverspec_eol/Gemfile`, with `kitchen verify` we get :
```
[...]
-----> Installing Busser plugin: busser-serverspec_eol
       Plugin serverspec_eol installed (version 0.5.11)
-----> Running postinstall for serverspec_eol plugin
       Suite path directory /tmp/verifier/suites does not exist, skipping.
       Transferring files to <datadog-rabbitmq-ec2-jessie>
-----> Running serverspec_eol test suite
-----> Installing net-ssh < 2.10
Fetching: net-ssh-2.9.4.gem (100%)
-----> Installing Serverspec..
[...]
```

After the fix, what it should be doing if we have a specific Gemfile in `[COOKBOOK]/test/integration/[SUITES]/serverspec_eol/Gemfile` :

```
-----> Installing Busser plugin: busser-serverspec_eol
       Plugin serverspec_eol installed (version 0.5.11)
-----> Running postinstall for serverspec_eol plugin
       Suite path directory /tmp/verifier/suites does not exist, skipping.
       Transferring files to <datadog-rabbitmq-ec2-jessie>
-----> Running serverspec_eol test suite
-----> Bundle Installing..
                run  /opt/chef/embedded/bin/ruby /tmp/verifier/gems/bin/bundle install --gemfile /tmp/verifier/suites/serverspec_eol/Gemfile --local || /opt/chef/embedded/bin/ruby /tmp/verifier/gems/bin/bundle install --gemfile /tmp/verifier/suites/serverspec_eol/Gemfile from "."
             [... Fetching and installing custom Gems from Gemfile...]
-----> Installing net-ssh < 2.10
Fetching: net-ssh-2.9.4.gem (100%)
-----> Installing Serverspec..
[...]
```

We cannot rely on a Gemfile located at `[COOKBOOK]/test/integration/[SUITES]/serverspec/Gemfile` because busser would then try to install **serverspec** plugin, which we want to avoid because it breaks with ruby < 2.3 (the whole point of the **serverspec_eol** fork).